### PR TITLE
Fix prefer-immediate-return

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ module.exports = {
     "no-proto": "error",
     "no-redeclare": "error",
     "no-return-assign": ["error", "always"],
-    "no-return-await": "error",
     "no-self-assign": "error",
     "no-self-compare": "error",
     "no-throw-literal": "warn",


### PR DESCRIPTION
Fix conflict between line 165 `"sonarjs/prefer-immediate-return": "error"` and 75 `"no-return-await": "error"`